### PR TITLE
Removed sql-script

### DIFF
--- a/src/main/resources/db/migration/V27__add_id_to_webhook_to_events.sql
+++ b/src/main/resources/db/migration/V27__add_id_to_webhook_to_events.sql
@@ -1,1 +1,0 @@
-alter table hook.webhook_to_events add IF NOT EXISTS id bigserial primary key;


### PR DESCRIPTION
Я короче не осознал, но скрипт не работает при накате 
SQL State  : 42P16
Error Code : 0
Message    : ERROR: multiple primary keys for table "webhook_to_events" are not allowed
Location   : db/migration/V27__add_id_to_webhook_to_events.sql (/opt/hooker/file:/opt/hooker/hooker.jar!/BOOT-INF/classes!/db/migration/V27__add_id_to_webhook_to_events.sql)
Line       : 1
Statement  : alter table hook.webhook_to_events add IF NOT EXISTS id bigserial primary key


при этом локально миграция проходит успешно